### PR TITLE
Add context manager support and unify client creation in BaseClient

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,14 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.11.8
     hooks:
       - id: ruff-format
       - id: ruff
         args: [ --fix, --unsafe-fixes ]
 
   - repo: https://github.com/pycqa/flake8
-    rev: '7.1.2'
+    rev: '7.2.0'
     hooks:
       - id: flake8
         args: ["--config=pyproject.toml"]

--- a/gefest_simple_rest_client/types_stubs.py
+++ b/gefest_simple_rest_client/types_stubs.py
@@ -25,6 +25,8 @@ class ClientOptions(TypedDict, total=False):
     transport: AsyncBaseTransport | None
     trust_env: bool
     default_encoding: str | Callable[[bytes], str]
+    auth: _types.AuthTypes | None
+    headers: dict[str, str] | None
 
 
 class RequestOptions(TypedDict, total=False):
@@ -50,3 +52,4 @@ class RequestOptions(TypedDict, total=False):
     files: _types.RequestFiles | None
     json: Any | None
     extensions: _types.RequestExtensions | None
+    auth: _types.AuthTypes | _client.UseClientDefault | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gefest_simple_rest_client"
-version = "1.2025.03.16"
+version = "1.2025.05.09"
 requires-python = ">=3.12"
 description = "Abstractions for create REST API client"
 readme = "README.md"


### PR DESCRIPTION
- Added **__enter__** and **__exit__** methods to support using the client as a sync context manager. 
- Introduced **_make_client_options** to apply user-defined settings during client creation. 
- Unified logic for sync and async client creation. 
- Updated pre-commit configuration and extended documentation with authorization usage examples.